### PR TITLE
Rename DEFAULT_TIMEOUT and add DEFAULT_IDLE_TIMEOUT

### DIFF
--- a/lib/rpush/daemon/dispatcher/apns_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apns_http2.rb
@@ -9,7 +9,8 @@ module Rpush
           sandbox: 'https://api.development.push.apple.com:443'
         }
 
-        DEFAULT_TIMEOUT = 60
+        DEFAULT_CONNECT_TIMEOUT = 60
+        DEFAULT_IDLE_TIMEOUT = 300
 
         def initialize(app, delivery_class, _options = {})
           @app = app
@@ -30,7 +31,7 @@ module Rpush
 
         def create_http2_client(app)
           url = URLS[app.environment.to_sym]
-          client = NetHttp2::Client.new(url, ssl_context: prepare_ssl_context, connect_timeout: DEFAULT_TIMEOUT)
+          client = NetHttp2::Client.new(url, ssl_context: prepare_ssl_context, connect_timeout: DEFAULT_CONNECT_TIMEOUT, idle_timeout: DEFAULT_IDLE_TIMEOUT)
           client.on(:error) do |error|
             log_error(error)
             reflect(:error, error)

--- a/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
+++ b/lib/rpush/daemon/dispatcher/apnsp8_http2.rb
@@ -10,7 +10,8 @@ module Rpush
           development: 'https://api.development.push.apple.com'
         }
 
-        DEFAULT_TIMEOUT = 60
+        DEFAULT_CONNECT_TIMEOUT = 60
+        DEFAULT_IDLE_TIMEOUT = 300
 
         def initialize(app, delivery_class, _options = {})
           @app = app
@@ -32,7 +33,7 @@ module Rpush
 
         def create_http2_client(app)
           url = URLS[app.environment.to_sym]
-          client = NetHttp2::Client.new(url, connect_timeout: DEFAULT_TIMEOUT)
+          client = NetHttp2::Client.new(url, connect_timeout: DEFAULT_CONNECT_TIMEOUT, idle_timeout: DEFAULT_IDLE_TIMEOUT)
           client.on(:error) do |error|
             log_error(error)
             reflect(:error, error)


### PR DESCRIPTION
We recently added an idle timeout to the IO.select call in net-http2.

This will allow rpush to use that timeout to perhaps prevent rpush/rpush#477